### PR TITLE
Refactor a lot of things for next major

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 vendor/
 build/
 phpunit.xml
+.phpunit.result.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,89 @@
+<?php
+
+$header = <<<'HEADER'
+This file is part of the PierstovalCharacterManagerBundle package.
+
+(c) Alexandre Rock Ancelet <pierstoval@gmail.com>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+HEADER;
+
+$finder = PhpCsFixer\Finder::create()
+    ->exclude([
+        'vendor',
+        'build',
+        'coverage',
+    ])
+    ->in([
+        __DIR__.'/Action/',
+        __DIR__.'/Controller/',
+        __DIR__.'/DependencyInjection/',
+        __DIR__.'/Entity/',
+        __DIR__.'/Exception/',
+        __DIR__.'/Model/',
+        __DIR__.'/Registry/',
+        __DIR__.'/Resolver/',
+        __DIR__.'/Tests/',
+    ])
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        'header_comment' => [
+            'header' => $header,
+        ],
+        // Enabled rules
+        '@DoctrineAnnotation'             => true,
+        '@Symfony'                        => true,
+        '@Symfony:risky'                  => true,
+        '@PhpCsFixer'                     => true,
+        '@PHP56Migration'                 => true,
+        '@PHP70Migration'                 => true,
+        '@PHP70Migration:risky'           => true,
+        '@PHP71Migration'                 => true,
+        '@PHP71Migration:risky'           => true,
+        '@PHP73Migration'                 => true,
+        'compact_nullable_typehint'       => true,
+        'fully_qualified_strict_types'    => true,
+        'heredoc_to_nowdoc'               => true,
+        'linebreak_after_opening_tag'     => true,
+        'logical_operators'               => true,
+        'mb_str_functions'                => true,
+        'native_function_invocation'      => true,
+        'no_null_property_initialization' => true,
+        'no_php4_constructor'             => true,
+        'no_short_echo_tag'               => true,
+        'no_superfluous_phpdoc_tags'      => true,
+        'no_useless_else'                 => true,
+        'no_useless_return'               => true,
+        'ordered_imports'                 => true,
+        'simplified_null_return'          => true,
+        'strict_param'                    => true,
+        'php_unit_test_case_static_method_calls' => [
+            'call_type' => 'static',
+        ],
+        'array_syntax'                    => [
+            'syntax' => 'short',
+        ],
+        // Overrides default doctrine rule using ":" as character
+        'doctrine_annotation_array_assignment' => [
+            'operator' => '=',
+        ],
+        'multiline_whitespace_before_semicolons' => [
+            'strategy' => 'new_line_for_chained_calls',
+        ],
+
+        // Disabled rules
+        'increment_style' => false,         // Because "++$i" is not always necessary…
+        'non_printable_character' => false, // Because I love using non breakable spaces in test methods ♥
+        'php_unit_test_class_requires_covers' => false, // Because we don't use @covers
+        'php_unit_internal_class' => false, // Why would this be necessary?
+        'heredoc_indentation' => false, // Well, it breaks the "visual" aspects of some strings...
+    ])
+    ->setRiskyAllowed(true)
+    ->setIndent('    ')
+    ->setLineEnding("\n")
+    ->setUsingCache(true)
+    ->setFinder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ matrix:
           env: 'ENABLE_CODE_COVERAGE="false"'
         - php: '7.3'
           env: 'ENABLE_CODE_COVERAGE="false"'
-        - php: '7.2'
+        - php: '7.3'
           env: 'ENABLE_CODE_COVERAGE="true"'
 
 before_install:
     - 'if [[ "$ENABLE_CODE_COVERAGE" != "true" ]]; then phpenv config-rm xdebug.ini; fi;'
-    - 'if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.0.0/php-coveralls.phar; fi;'
+    - 'if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.1.0/php-coveralls.phar; fi;'
 
 install:
     - composer update --prefer-dist --no-interaction --optimize-autoloader

--- a/Action/AbstractStepAction.php
+++ b/Action/AbstractStepAction.php
@@ -111,6 +111,11 @@ abstract class AbstractStepAction implements StepActionInterface
         return $this->step;
     }
 
+    public function stepName(): string
+    {
+        return $this->step->getName();
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/Action/AbstractStepAction.php
+++ b/Action/AbstractStepAction.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -15,12 +17,12 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Pierstoval\Bundle\CharacterManagerBundle\Model\CharacterInterface;
 use Pierstoval\Bundle\CharacterManagerBundle\Model\StepInterface;
 use Pierstoval\Bundle\CharacterManagerBundle\Resolver\StepResolverInterface;
-use Twig\Environment;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
 
 abstract class AbstractStepAction implements StepActionInterface
 {
@@ -59,12 +61,19 @@ abstract class AbstractStepAction implements StepActionInterface
     /** @var TranslatorInterface */
     protected $translator;
 
+    private $configured = false;
+
     public function configure(string $managerName, string $stepName, string $characterClassName, StepResolverInterface $resolver): void
     {
-        if (!class_exists($characterClassName) || !is_subclass_of($characterClassName, CharacterInterface::class, true)) {
-            throw new \InvalidArgumentException(sprintf(
+        if ($this->configured) {
+            throw new \RuntimeException('Cannot reconfigure an already configured step action.');
+        }
+
+        if (!\class_exists($characterClassName) || !\is_subclass_of($characterClassName, CharacterInterface::class, true)) {
+            throw new \InvalidArgumentException(\sprintf(
                 'Step action must be a valid class implementing %s. "%s" given.',
-                CharacterInterface::class, class_exists($characterClassName) ? $characterClassName : \gettype($characterClassName)
+                CharacterInterface::class,
+                \class_exists($characterClassName) ? $characterClassName : \gettype($characterClassName)
             ));
         }
 
@@ -72,6 +81,8 @@ abstract class AbstractStepAction implements StepActionInterface
         $this->managerName = $managerName;
         $this->step = $resolver->resolve($stepName, $managerName);
         $this->setSteps($resolver->getManagerSteps($managerName));
+
+        $this->configured = true;
     }
 
     /**
@@ -138,9 +149,6 @@ abstract class AbstractStepAction implements StepActionInterface
         return $character[$key] ?? null;
     }
 
-    /**
-     * @return RedirectResponse
-     */
     protected function nextStep(): RedirectResponse
     {
         return $this->goToStep($this->getStep()->getNumber() + 1);
@@ -148,10 +156,6 @@ abstract class AbstractStepAction implements StepActionInterface
 
     /**
      * Redirects to a specific step and updates the session.
-     *
-     * @param int $stepNumber
-     *
-     * @return RedirectResponse
      */
     protected function goToStep(int $stepNumber): RedirectResponse
     {
@@ -170,9 +174,6 @@ abstract class AbstractStepAction implements StepActionInterface
         throw new \InvalidArgumentException('Invalid step: '.$stepNumber);
     }
 
-    /**
-     * @param mixed $value
-     */
     protected function updateCharacterStep($value): void
     {
         $character = $this->getCurrentCharacter();
@@ -199,7 +200,7 @@ abstract class AbstractStepAction implements StepActionInterface
 
         $msg = $this->translator
             ? $this->translator->trans($msg, $msgParams, static::$translationDomain)
-            : strtr($msg, $msgParams)
+            : \strtr($msg, $msgParams)
         ;
 
         $flashbag = $this->getSession()->getFlashBag();
@@ -209,7 +210,7 @@ abstract class AbstractStepAction implements StepActionInterface
         $existingMessages[] = $msg;
 
         // And avoid having the same message multiple times.
-        $flashbag->set($type, array_unique($existingMessages));
+        $flashbag->set($type, \array_unique($existingMessages));
 
         return $this;
     }
@@ -241,9 +242,10 @@ abstract class AbstractStepAction implements StepActionInterface
     {
         foreach ($steps as $step) {
             if (!$step instanceof StepInterface) {
-                throw new \InvalidArgumentException(sprintf(
+                throw new \InvalidArgumentException(\sprintf(
                     'Expected %s instance, "%s" given.',
-                    StepActionInterface::class, \is_object($step) ? \get_class($step) : \gettype($step)
+                    StepActionInterface::class,
+                    \is_object($step) ? \get_class($step) : \gettype($step)
                 ));
             }
         }

--- a/Action/StepActionInterface.php
+++ b/Action/StepActionInterface.php
@@ -22,8 +22,6 @@ interface StepActionInterface
      * Any step action is like a controller action: we inject the request to it, and we need a response.
      * As we can have tons of steps, it's much better to rely on action pattern,
      *   rather than one controller with tons of methods.
-     *
-     * @return Response
      */
     public function execute(): Response;
 
@@ -32,15 +30,12 @@ interface StepActionInterface
      */
     public function configure(string $managerName, string $stepName, string $characterClassName, StepResolverInterface $resolver): void;
 
-    /**
-     * @return StepInterface
-     */
     public function getStep(): StepInterface;
+
+    public function stepName(): string;
 
     /**
      * Current Request object that will be used in the Step action.
-     *
-     * @param Request $request
      */
     public function setRequest(Request $request): void;
 }

--- a/Action/StepActionInterface.php
+++ b/Action/StepActionInterface.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>

--- a/Controller/GeneratorController.php
+++ b/Controller/GeneratorController.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -64,14 +66,14 @@ class GeneratorController
         $resolvedManagerName = $this->stepsResolver->resolveManagerName($manager);
 
         try {
-            $step = $this->stepsResolver->resolveNumber($session->get("step.$resolvedManagerName", 1), $resolvedManagerName);
+            $step = $this->stepsResolver->resolveNumber($session->get("step.{$resolvedManagerName}", 1), $resolvedManagerName);
         } catch (StepNotFoundException $e) {
             throw new NotFoundHttpException('No step found to start the generator.', $e);
         }
 
         $routeParams = ['requestStep' => $step->getName()];
 
-        if ($manager !== null) {
+        if (null !== $manager) {
             $routeParams['manager'] = $manager;
         }
 
@@ -84,8 +86,8 @@ class GeneratorController
 
         $resolvedManagerName = $this->stepsResolver->resolveManagerName($manager);
 
-        $session->set("character.$resolvedManagerName", []);
-        $session->set("step.$resolvedManagerName", 1);
+        $session->set("character.{$resolvedManagerName}", []);
+        $session->set("step.{$resolvedManagerName}", 1);
         $session->getFlashBag()->add('success', $this->trans('steps.reset.character', [], 'PierstovalCharacterManager'));
 
         return new RedirectResponse($this->router->generate('pierstoval_character_generator_index'));
@@ -103,20 +105,20 @@ class GeneratorController
             throw new NotFoundHttpException('Step not found.', $e);
         }
 
-        $character = $session->get("character.$resolvedManagerName", []);
+        $character = $session->get("character.{$resolvedManagerName}", []);
         unset($character[$step->getName()]);
 
         foreach ($step->getOnchangeClear() as $stepToClear) {
             unset($character[$stepToClear]);
         }
 
-        $session->set("character.$resolvedManagerName", $character);
+        $session->set("character.{$resolvedManagerName}", $character);
 
         $session->getFlashBag()->add('success', $this->trans('steps.reset.step', [], 'PierstovalCharacterManager'));
 
         $routeParams = ['requestStep' => $step->getName()];
 
-        if ($manager !== null) {
+        if (null !== $manager) {
             $routeParams['manager'] = $manager;
         }
 
@@ -135,7 +137,7 @@ class GeneratorController
             throw new NotFoundHttpException('Step not found.', $e);
         }
 
-        $character = $session->get("character.$resolvedManagerName", []);
+        $character = $session->get("character.{$resolvedManagerName}", []);
 
         // Make sure that dependencies exist, else redirect to first step with a message.
         foreach ($step->getDependencies() as $stepName) {

--- a/DependencyInjection/Compiler/StepsPass.php
+++ b/DependencyInjection/Compiler/StepsPass.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -16,7 +18,6 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Pierstoval\Bundle\CharacterManagerBundle\Action\AbstractStepAction;
 use Pierstoval\Bundle\CharacterManagerBundle\Action\StepActionInterface;
 use Pierstoval\Bundle\CharacterManagerBundle\Registry\ActionsRegistry;
-use Pierstoval\Bundle\CharacterManagerBundle\Resolver\StepActionConfigurator;
 use Pierstoval\Bundle\CharacterManagerBundle\Resolver\StepResolverInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
@@ -41,7 +42,7 @@ class StepsPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->validateManagers($container);
         $this->processConfiguredServices($container);
@@ -60,7 +61,7 @@ class StepsPass implements CompilerPassInterface
     }
 
     /**
-     * Validate steps defined in configuration, and makes sure all "action" classes are instances of StepActionInterface
+     * Validate steps defined in configuration, and makes sure all "action" classes are instances of StepActionInterface.
      */
     private function validateManagerSteps(array $managerConfiguration, ContainerBuilder $container): array
     {
@@ -88,22 +89,24 @@ class StepsPass implements CompilerPassInterface
         foreach ($steps as $name => $step) {
             // Validate steps to disable on change, to be sure each step is defined.
             foreach ($step['onchange_clear'] as $stepToDisable) {
-                if (!array_key_exists($stepToDisable, $steps)) {
-                    throw new InvalidConfigurationException(sprintf(
+                if (!\array_key_exists($stepToDisable, $steps)) {
+                    throw new InvalidConfigurationException(\sprintf(
                         'Step to disable must be a valid step name, "%s" given.'."\n".
                         'Available steps: %s',
-                        $stepToDisable, implode(', ', array_keys($steps))
+                        $stepToDisable,
+                        \implode(', ', \array_keys($steps))
                     ));
                 }
             }
 
             // Validate steps dependencies, to be sure each step is defined.
             foreach ($step['dependencies'] as $stepDependency) {
-                if (!array_key_exists($stepDependency, $steps)) {
-                    throw new InvalidConfigurationException(sprintf(
+                if (!\array_key_exists($stepDependency, $steps)) {
+                    throw new InvalidConfigurationException(\sprintf(
                         'Step dependency must be a valid step name, "%s" given.'."\n".
                         'Available steps: %s',
-                        $stepDependency, implode(', ', array_keys($steps))
+                        $stepDependency,
+                        \implode(', ', \array_keys($steps))
                     ));
                 }
             }
@@ -114,10 +117,11 @@ class StepsPass implements CompilerPassInterface
             // Check if action defined as a service or as a simple class.
             $class = $container->has($action) ? $container->getDefinition($action)->getClass() : $action;
 
-            if (!class_exists($class) || !is_a($class, StepActionInterface::class, true)) {
-                throw new InvalidArgumentException(sprintf(
+            if (!\class_exists($class) || !\is_a($class, StepActionInterface::class, true)) {
+                throw new InvalidArgumentException(\sprintf(
                     'Step action must be a valid class implementing %s. "%s" given.',
-                    StepActionInterface::class, class_exists($class) ? $class : \gettype($class)
+                    StepActionInterface::class,
+                    \class_exists($class) ? $class : \gettype($class)
                 ));
             }
         }
@@ -131,10 +135,8 @@ class StepsPass implements CompilerPassInterface
     /**
      * Automatically convert the actions into services.
      * If they're defined as classes, this has the advantage to autowire them, etc.
-     *
-     * @param ContainerBuilder $container
      */
-    private function processConfiguredServices(ContainerBuilder $container)
+    private function processConfiguredServices(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(ActionsRegistry::class)) {
             throw new InvalidConfigurationException('Step actions registry not set in your configuration. Maybe the extension was not processed properly?');
@@ -155,7 +157,7 @@ class StepsPass implements CompilerPassInterface
         foreach ($finalSteps as $step) {
             $action = $step['action'];
             if ($container->has($action)) {
-                /** @var  $definition */
+                /** @var $definition */
                 $definition = $container->getDefinition($action);
             } else {
                 // If action is not yet a service, it means it's a class name.
@@ -178,17 +180,17 @@ class StepsPass implements CompilerPassInterface
             ;
 
             // If class extends the abstract one, we inject some cool services.
-            if (is_a($definition->getClass(), AbstractStepAction::class, true)) {
-                if ($container->hasDefinition(ObjectManager::class)) {
+            if (\is_a($definition->getClass(), AbstractStepAction::class, true)) {
+                if ($container->hasDefinition(ObjectManager::class) || $container->hasAlias(ObjectManager::class)) {
                     $definition->addMethodCall('setObjectManager', [new Reference(ObjectManager::class)]);
                 }
-                if ($container->hasDefinition(Environment::class)) {
+                if ($container->hasDefinition(Environment::class) || $container->hasAlias(Environment::class)) {
                     $definition->addMethodCall('setTwig', [new Reference(Environment::class)]);
                 }
-                if ($container->hasDefinition(RouterInterface::class)) {
+                if ($container->hasDefinition(RouterInterface::class) || $container->hasAlias(RouterInterface::class)) {
                     $definition->addMethodCall('setRouter', [new Reference(RouterInterface::class)]);
                 }
-                if ($container->hasDefinition(TranslatorInterface::class)) {
+                if ($container->hasDefinition(TranslatorInterface::class) || $container->hasAlias(TranslatorInterface::class)) {
                     $definition->addMethodCall('setTranslator', [new Reference(TranslatorInterface::class)]);
                 }
             }
@@ -200,6 +202,6 @@ class StepsPass implements CompilerPassInterface
 
     private function generateStepLabel(string $name): string
     {
-        return Inflector::ucwords(trim(str_replace(['.', '_', '-'], ' ', $name)));
+        return Inflector::ucwords(\trim(\str_replace(['.', '_', '-'], ' ', $name)));
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -27,7 +29,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode    = $treeBuilder->root('pierstoval_character_manager');
+        $rootNode = $treeBuilder->root('pierstoval_character_manager');
 
         $rootNode
             ->addDefaultsIfNotSet()

--- a/DependencyInjection/PierstovalCharacterManagerExtension.php
+++ b/DependencyInjection/PierstovalCharacterManagerExtension.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -27,10 +29,10 @@ class PierstovalCharacterManagerExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
-        $config        = $this->processConfiguration($configuration, $configs);
+        $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/Entity/Character.php
+++ b/Entity/Character.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>

--- a/Exception/StepNotFoundException.php
+++ b/Exception/StepNotFoundException.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -18,6 +20,6 @@ class StepNotFoundException extends \RuntimeException
      */
     public function __construct($step, string $managerName)
     {
-        parent::__construct("\"$step\" step does not exist in manager $managerName.");
+        parent::__construct("\"{$step}\" step does not exist in manager {$managerName}.");
     }
 }

--- a/Model/CharacterInterface.php
+++ b/Model/CharacterInterface.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>

--- a/Model/Step.php
+++ b/Model/Step.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -30,16 +32,16 @@ class Step implements StepInterface
         array $onchangeClear,
         array $dependencies
     ) {
-        $this->number        = $number;
-        $this->name          = $name;
-        $this->action        = $action;
-        $this->label         = $label;
-        $this->managerName   = $managerName;
+        $this->number = $number;
+        $this->name = $name;
+        $this->action = $action;
+        $this->label = $label;
+        $this->managerName = $managerName;
         $this->onchangeClear = $onchangeClear;
-        $this->dependencies  = $dependencies;
+        $this->dependencies = $dependencies;
     }
 
-    public static function createFromData(array $data): Step
+    public static function createFromData(array $data): self
     {
         return new static(
             $data['number'],

--- a/Model/StepInterface.php
+++ b/Model/StepInterface.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>

--- a/Registry/ActionsRegistry.php
+++ b/Registry/ActionsRegistry.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -31,8 +33,8 @@ class ActionsRegistry implements ActionsRegistryInterface
             throw new \RuntimeException('No actions in the registry.');
         }
 
-        if ($manager === null) {
-            $manager = array_keys($this->actions)[0];
+        if (null === $manager) {
+            $manager = \array_keys($this->actions)[0];
         }
 
         if (!isset($this->actions[$manager])) {
@@ -43,9 +45,10 @@ class ActionsRegistry implements ActionsRegistryInterface
         }
 
         if (!isset($this->actions[$manager][$stepName])) {
-                throw new \InvalidArgumentException(\sprintf(
+            throw new \InvalidArgumentException(\sprintf(
                 'Step "%s" not found in manager "%s".',
-                $stepName, $manager
+                $stepName,
+                $manager
             ));
         }
 
@@ -57,7 +60,10 @@ class ActionsRegistry implements ActionsRegistryInterface
             if (!$action instanceof StepActionInterface) {
                 throw new \RuntimeException(\sprintf(
                     "Lazy-loaded action \"%s\" for character manager \"%s\" must be resolved to an instance of \"%s\".\n\"%s\" given.",
-                    $stepName, $manager, StepActionInterface::class, \is_object($action) ? \get_class($action) : \gettype($action)
+                    $stepName,
+                    $manager,
+                    StepActionInterface::class,
+                    \is_object($action) ? \get_class($action) : \gettype($action)
                 ));
             }
             $this->actions[$manager][$stepName] = $action;

--- a/Registry/ActionsRegistryInterface.php
+++ b/Registry/ActionsRegistryInterface.php
@@ -16,6 +16,11 @@ use Pierstoval\Bundle\CharacterManagerBundle\Action\StepActionInterface;
 interface ActionsRegistryInterface
 {
     /**
+     * @param StepActionInterface|\Closure $action If it's a callable, it's lazy-loaded.
+     */
+    public function addStepAction(string $manager, string $stepName, $action): void;
+
+    /**
      * @throws \RuntimeException if there are no managers available.
      * @throws \InvalidArgumentException for an action that do not exist.
      * @throws \InvalidArgumentException for a manager that do not exist.

--- a/Registry/ActionsRegistryInterface.php
+++ b/Registry/ActionsRegistryInterface.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -16,14 +18,14 @@ use Pierstoval\Bundle\CharacterManagerBundle\Action\StepActionInterface;
 interface ActionsRegistryInterface
 {
     /**
-     * @param StepActionInterface|\Closure $action If it's a callable, it's lazy-loaded.
+     * @param \Closure|StepActionInterface $action if it's a callable, it's lazy-loaded
      */
     public function addStepAction(string $manager, string $stepName, $action): void;
 
     /**
-     * @throws \RuntimeException if there are no managers available.
-     * @throws \InvalidArgumentException for an action that do not exist.
-     * @throws \InvalidArgumentException for a manager that do not exist.
+     * @throws \RuntimeException         if there are no managers available
+     * @throws \InvalidArgumentException for an action that do not exist
+     * @throws \InvalidArgumentException for a manager that do not exist
      */
     public function getAction(string $stepName, string $manager = null): StepActionInterface;
 }

--- a/Resolver/StepResolver.php
+++ b/Resolver/StepResolver.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -69,24 +71,24 @@ class StepResolver implements StepResolverInterface
 
     public function resolveManagerName(string $managerName = null): string
     {
-        if (\count($this->managersConfiguration) === 0) {
+        if (0 === \count($this->managersConfiguration)) {
             throw new \RuntimeException('No character managers to resolve configuration for.');
         }
 
-        if ($managerName === null && \count($this->managersConfiguration) > 0) {
-            if (\count($this->managersConfiguration) === 1) {
-                return array_keys($this->managersConfiguration)[0];
+        if (null === $managerName && \count($this->managersConfiguration) > 0) {
+            if (1 === \count($this->managersConfiguration)) {
+                return \array_keys($this->managersConfiguration)[0];
             }
 
-            throw new \InvalidArgumentException(sprintf(
+            throw new \InvalidArgumentException(\sprintf(
                 'You did not specify which character manager you want to get the steps from, and you have more than one manager. '.
                 'Possible choices: %s',
-                implode(', ', array_keys($this->managersConfiguration))
+                \implode(', ', \array_keys($this->managersConfiguration))
             ));
         }
 
         if (!isset($this->managersConfiguration[$managerName])) {
-            throw new \InvalidArgumentException("\"$managerName\" manager does not exist, or is not initialized yet.");
+            throw new \InvalidArgumentException("\"{$managerName}\" manager does not exist, or is not initialized yet.");
         }
 
         return $managerName;

--- a/Resolver/StepResolver.php
+++ b/Resolver/StepResolver.php
@@ -67,26 +67,6 @@ class StepResolver implements StepResolverInterface
         throw new StepNotFoundException($stepNumber, $managerName);
     }
 
-    private function resolveManagerSteps(string $managerName = null): void
-    {
-        $managerName = $this->resolveManagerName($managerName);
-
-        if (isset($this->steps[$managerName])) {
-            return;
-        }
-
-        // Transform array of array in array of value objects.
-        foreach ($this->managersConfiguration as $manager => $config) {
-            if ($manager !== $managerName) {
-                continue;
-            }
-            $this->steps[$manager] = [];
-            foreach ($config['steps'] as $key => $stepArray) {
-                $this->steps[$manager][$key] = Step::createFromData($stepArray);
-            }
-        }
-    }
-
     public function resolveManagerName(string $managerName = null): string
     {
         if (\count($this->managersConfiguration) === 0) {
@@ -110,5 +90,25 @@ class StepResolver implements StepResolverInterface
         }
 
         return $managerName;
+    }
+
+    private function resolveManagerSteps(string $managerName = null): void
+    {
+        $managerName = $this->resolveManagerName($managerName);
+
+        if (isset($this->steps[$managerName])) {
+            return;
+        }
+
+        // Transform array of array in array of value objects.
+        foreach ($this->managersConfiguration as $manager => $config) {
+            if ($manager !== $managerName) {
+                continue;
+            }
+            $this->steps[$manager] = [];
+            foreach ($config['steps'] as $key => $stepArray) {
+                $this->steps[$manager][$key] = Step::createFromData($stepArray);
+            }
+        }
     }
 }

--- a/Resolver/StepResolverInterface.php
+++ b/Resolver/StepResolverInterface.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -23,12 +25,14 @@ interface StepResolverInterface
 {
     /**
      * Resolves a step object based on a step identifier.
+     *
      * @throws StepNotFoundException if step does not exist
      */
     public function resolve(string $stepName, string $managerName = null): StepInterface;
 
     /**
      * Resolves a step object based on a step number.
+     *
      * @throws StepNotFoundException if step number does not exist
      */
     public function resolveNumber(int $stepNumber, string $managerName = null): StepInterface;

--- a/Tests/Action/AbstractActionTest.php
+++ b/Tests/Action/AbstractActionTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -29,7 +31,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
     /**
      * @dataProvider provideMethodsThatDependOnStepObject
      */
-    public function test any method depending on step object throws exception(string $method, array $arguments = [])
+    public function test any method depending on step object throws exception(string $method, array $arguments = []): void
     {
         $stub = new ConcreteAbstractActionStub();
         $stub->setRequest($this->createRequest());
@@ -40,7 +42,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->{$method}(...$arguments);
     }
 
-    public function test configure with wrong character class throws exception()
+    public function test configure with wrong character class throws exception(): void
     {
         $stub = new ConcreteAbstractActionStub();
 
@@ -50,7 +52,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->configure('', '', \stdClass::class, $this->createMock(StepResolverInterface::class));
     }
 
-    public function test configure with wrong character class type throws exception()
+    public function test configure with wrong character class type throws exception(): void
     {
         $stub = new ConcreteAbstractActionStub();
 
@@ -60,12 +62,12 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->configure('', '', 'wrong_class_name', $this->createMock(StepResolverInterface::class));
     }
 
-    public function test configure with wrong steps class throws exception()
+    public function test configure with wrong steps class throws exception(): void
     {
         $stub = new ConcreteAbstractActionStub();
         $resolver = $this->createMock(StepResolverInterface::class);
-        $resolver->expects($this->once())->method('resolve');
-        $resolver->expects($this->once())->method('getManagerSteps')->willReturn([new \stdClass]);
+        $resolver->expects(static::once())->method('resolve');
+        $resolver->expects(static::once())->method('getManagerSteps')->willReturn([new \stdClass()]);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected Pierstoval\Bundle\CharacterManagerBundle\Action\StepActionInterface instance, "stdClass" given.');
@@ -73,17 +75,29 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->configure('', '', CharacterStub::class, $resolver);
     }
 
-    public function test configure with wrong steps type throws exception()
+    public function test configure with wrong steps type throws exception(): void
     {
         $stub = new ConcreteAbstractActionStub();
         $resolver = $this->createMock(StepResolverInterface::class);
-        $resolver->expects($this->once())->method('resolve');
-        $resolver->expects($this->once())->method('getManagerSteps')->willReturn(['error']);
+        $resolver->expects(static::once())->method('resolve');
+        $resolver->expects(static::once())->method('getManagerSteps')->willReturn(['error']);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected Pierstoval\Bundle\CharacterManagerBundle\Action\StepActionInterface instance, "string" given.');
 
         $stub->configure('', '', CharacterStub::class, $resolver);
+    }
+
+    public function test configure an already configured action throws exception(): void
+    {
+        $stub = new ConcreteAbstractActionStub();
+
+        $stub->configure('', '', CharacterStub::class, $this->createMock(StepResolverInterface::class));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot reconfigure an already configured step action.');
+
+        $stub->configure('', '', CharacterStub::class, $this->createMock(StepResolverInterface::class));
     }
 
     public function provideMethodsThatDependOnStepObject()
@@ -93,13 +107,13 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         yield ['nextStep', []];
     }
 
-    public function test next step should increment in session()
+    public function test next step should increment in session(): void
     {
-        /** @var RouterInterface|MockObject $router */
+        /** @var MockObject|RouterInterface $router */
         $router = $this->createMock(RouterInterface::class);
 
         $router
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('generate')
             ->with('pierstoval_character_generator_step', ['requestStep' => 'step_2'])
             ->willReturn('/steps/step_2')
@@ -112,7 +126,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
                 ],
                 'step_2' => [
                     'number' => 2,
-                ]
+                ],
             ]),
         ]);
 
@@ -130,7 +144,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertTrue($response->isRedirect('/steps/step_2'));
     }
 
-    public function test getCurrentCharacter with a correct session value()
+    public function test getCurrentCharacter with a correct session value(): void
     {
         $stub = $this->getDefaultStub();
 
@@ -144,7 +158,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertSame($stub->getCurrentCharacter(), $value);
     }
 
-    public function test getCharacterProperty with no key()
+    public function test getCharacterProperty with no key(): void
     {
         $stub = $this->getDefaultStub();
 
@@ -158,7 +172,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertSame($value['test_step'], $stub->getCharacterProperty());
     }
 
-    public function test getCharacterProperty with valid key()
+    public function test getCharacterProperty with valid key(): void
     {
         $stub = $this->getDefaultStub();
 
@@ -172,7 +186,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertSame($value['test_step'], $stub->getCharacterProperty('test_step'));
     }
 
-    public function test getCharacterProperty with non existent key()
+    public function test getCharacterProperty with non existent key(): void
     {
         $stub = $this->getDefaultStub();
 
@@ -181,13 +195,13 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertNull($stub->getCharacterProperty('non_existent_key'));
     }
 
-    public function test update current step value()
+    public function test update current step value(): void
     {
         $stub = new ConcreteAbstractActionStub();
         $stepStub = StepStub::createStub(['number' => 2, 'name' => 'step_1']);
         $resolver = $this->createMock(StepResolverInterface::class);
-        $resolver->expects($this->once())->method('resolve')->willReturn($stepStub);
-        $resolver->expects($this->once())->method('getManagerSteps')->willReturn([$stepStub]);
+        $resolver->expects(static::once())->method('resolve')->willReturn($stepStub);
+        $resolver->expects(static::once())->method('getManagerSteps')->willReturn([$stepStub]);
 
         $stub->configure($stepStub->getManagerName(), $stepStub->getName(), CharacterStub::class, $resolver);
 
@@ -202,13 +216,13 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertSame(2, $request->getSession()->get('step.test_manager'));
     }
 
-    public function test update current step unsets steps that have to be changed()
+    public function test update current step unsets steps that have to be changed(): void
     {
         $stub = new ConcreteAbstractActionStub();
         $stepStub = StepStub::createStub(['number' => 2, 'name' => 'step_1', 'onchange_clear' => ['step_2', 'step_3']]);
         $resolver = $this->createMock(StepResolverInterface::class);
-        $resolver->expects($this->once())->method('resolve')->willReturn($stepStub);
-        $resolver->expects($this->once())->method('getManagerSteps')->willReturn([$stepStub]);
+        $resolver->expects(static::once())->method('resolve')->willReturn($stepStub);
+        $resolver->expects(static::once())->method('getManagerSteps')->willReturn([$stepStub]);
         $step = new Step(2, 'step_1', \get_class($stub), 'step_1', 'main_manager', ['step_2', 'step_3'], []);
 
         // Prepare request & session
@@ -228,13 +242,13 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertArrayNotHasKey('step_3', $request->getSession()->get('character.test_manager'));
     }
 
-    public function test goToStep returns RedirectResponse object()
+    public function test goToStep returns RedirectResponse object(): void
     {
-        /** @var RouterInterface|MockObject $router */
+        /** @var MockObject|RouterInterface $router */
         $router = $this->createMock(RouterInterface::class);
 
         $router
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('generate')
             ->with('pierstoval_character_generator_step', ['requestStep' => 'step_3'])
             ->willReturn('/steps/step_3')
@@ -246,8 +260,8 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $step2 = new Step(2, 'step_2', \get_class($stub), 'step_2', 'test_manager', [], []);
         $step3 = new Step(3, 'step_3', \get_class($stub), 'step_3', 'test_manager', [], []);
         $resolver = $this->createMock(StepResolverInterface::class);
-        $resolver->expects($this->once())->method('resolve')->willReturn($step1);
-        $resolver->expects($this->once())->method('getManagerSteps')->willReturn([$step1, $step2, $step3]);
+        $resolver->expects(static::once())->method('resolve')->willReturn($step1);
+        $resolver->expects(static::once())->method('getManagerSteps')->willReturn([$step1, $step2, $step3]);
         $stub->setRouter($router);
         $request = $this->createRequest();
         $stub->configure('test_manager', 'step_1', CharacterStub::class, $resolver);
@@ -259,7 +273,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertSame(3, $request->getSession()->get('step.test_manager'));
     }
 
-    public function test goToStep throws exception if no router()
+    public function test goToStep throws exception if no router(): void
     {
         $stub = new ConcreteAbstractActionStub();
 
@@ -269,9 +283,9 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->goToStep(1);
     }
 
-    public function test goToStep throws exception if step does not exist()
+    public function test goToStep throws exception if step does not exist(): void
     {
-        /** @var RouterInterface|MockObject $router */
+        /** @var MockObject|RouterInterface $router */
         $router = $this->createMock(RouterInterface::class);
 
         $stub = new ConcreteAbstractActionStub();
@@ -283,7 +297,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->goToStep(25);
     }
 
-    public function test flashMessage should throw exception if no request()
+    public function test flashMessage should throw exception if no request(): void
     {
         $stub = new ConcreteAbstractActionStub();
 
@@ -293,7 +307,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->flashMessage('message');
     }
 
-    public function test flashMessage should throw exception if no session()
+    public function test flashMessage should throw exception if no session(): void
     {
         $stub = new ConcreteAbstractActionStub();
         $stub->setRequest(new Request());
@@ -304,7 +318,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->flashMessage('message');
     }
 
-    public function test flashMessage with no parameters()
+    public function test flashMessage with no parameters(): void
     {
         $stub = new ConcreteAbstractActionStub();
         $request = $this->createRequest();
@@ -315,7 +329,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertSame(['message'], $stub->getSession()->getFlashBag()->get('error'));
     }
 
-    public function test flashMessage removes duplicates()
+    public function test flashMessage removes duplicates(): void
     {
         $stub = new ConcreteAbstractActionStub();
         $request = $this->createRequest();
@@ -328,7 +342,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertSame(['message'], $stub->getSession()->getFlashBag()->get('error'));
     }
 
-    public function test flashMessage with parameters()
+    public function test flashMessage with parameters(): void
     {
         $stub = new ConcreteAbstractActionStub();
         $request = $this->createRequest();
@@ -340,14 +354,14 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertSame(['Message with REPLACEMENT'], $stub->getSession()->getFlashBag()->get('error'));
     }
 
-    public function test flashMessage with translator()
+    public function test flashMessage with translator(): void
     {
         $stub = new ConcreteAbstractActionStub();
         $request = $this->createRequest();
         $stub->setRequest($request);
 
         $translatorMock = $this->createMock(TranslatorInterface::class);
-        $translatorMock->expects($this->once())
+        $translatorMock->expects(static::once())
             ->method('trans')
             ->with('message')
             ->willReturn('translated')
@@ -359,7 +373,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertSame(['translated'], $stub->getSession()->getFlashBag()->get('error'));
     }
 
-    public function test update current step should throw exception if no request()
+    public function test update current step should throw exception if no request(): void
     {
         $stub = new ConcreteAbstractActionStub();
 
@@ -369,7 +383,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->updateCharacterStep(null);
     }
 
-    public function test getCurrentCharacter should throw exception if no request()
+    public function test getCurrentCharacter should throw exception if no request(): void
     {
         $stub = new ConcreteAbstractActionStub();
 
@@ -379,7 +393,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->getCurrentCharacter();
     }
 
-    public function test getCurrentCharacter should throw exception if no session()
+    public function test getCurrentCharacter should throw exception if no session(): void
     {
         $stub = new ConcreteAbstractActionStub();
         $stub->setRequest(new Request());
@@ -390,7 +404,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->getCurrentCharacter();
     }
 
-    public function test invalid character class in step action()
+    public function test invalid character class in step action(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Step action must be a valid class implementing Pierstoval\Bundle\CharacterManagerBundle\Model\CharacterInterface. "stdClass" given.');
@@ -399,7 +413,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->configure('', '', \stdClass::class, $this->createMock(StepResolverInterface::class));
     }
 
-    public function test flash message when session is not available()
+    public function test flash message when session is not available(): void
     {
         $action = new ConcreteAbstractActionStub();
         $action->setRequest(new Request());
@@ -415,8 +429,8 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub = new ConcreteAbstractActionStub();
         $stepStub = StepStub::createStub();
         $resolver = $this->createMock(StepResolverInterface::class);
-        $resolver->expects($this->once())->method('resolve')->willReturn($stepStub);
-        $resolver->expects($this->once())->method('getManagerSteps')->willReturn([$stepStub]);
+        $resolver->expects(static::once())->method('resolve')->willReturn($stepStub);
+        $resolver->expects(static::once())->method('getManagerSteps')->willReturn([$stepStub]);
 
         $stub->configure($stepStub->getManagerName(), $stepStub->getName(), CharacterStub::class, $resolver);
 

--- a/Tests/Action/AbstractActionTest.php
+++ b/Tests/Action/AbstractActionTest.php
@@ -20,8 +20,6 @@ use Pierstoval\Bundle\CharacterManagerBundle\Tests\Controller\AbstractGeneratorC
 use Pierstoval\Bundle\CharacterManagerBundle\Tests\Fixtures\Stubs\Action\ConcreteAbstractActionStub;
 use Pierstoval\Bundle\CharacterManagerBundle\Tests\Fixtures\Stubs\Entity\CharacterStub;
 use Pierstoval\Bundle\CharacterManagerBundle\Tests\Fixtures\Stubs\Model\StepStub;
-use RuntimeException;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -30,60 +28,61 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
 {
     /**
      * @dataProvider provideMethodsThatDependOnStepObject
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Step is not defined in current step action. Did you run the "configure()" method?
      */
     public function test any method depending on step object throws exception(string $method, array $arguments = [])
     {
         $stub = new ConcreteAbstractActionStub();
         $stub->setRequest($this->createRequest());
 
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Step is not defined in current step action. Did you run the "configure()" method?');
+
         $stub->{$method}(...$arguments);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Step action must be a valid class implementing Pierstoval\Bundle\CharacterManagerBundle\Model\CharacterInterface. "stdClass" given.
-     */
     public function test configure with wrong character class throws exception()
     {
         $stub = new ConcreteAbstractActionStub();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Step action must be a valid class implementing Pierstoval\Bundle\CharacterManagerBundle\Model\CharacterInterface. "stdClass" given.');
+
         $stub->configure('', '', \stdClass::class, $this->createMock(StepResolverInterface::class));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Step action must be a valid class implementing Pierstoval\Bundle\CharacterManagerBundle\Model\CharacterInterface. "string" given.
-     */
     public function test configure with wrong character class type throws exception()
     {
         $stub = new ConcreteAbstractActionStub();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Step action must be a valid class implementing Pierstoval\Bundle\CharacterManagerBundle\Model\CharacterInterface. "string" given.');
+
         $stub->configure('', '', 'wrong_class_name', $this->createMock(StepResolverInterface::class));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Expected Pierstoval\Bundle\CharacterManagerBundle\Action\StepActionInterface instance, "stdClass" given.
-     */
     public function test configure with wrong steps class throws exception()
     {
         $stub = new ConcreteAbstractActionStub();
         $resolver = $this->createMock(StepResolverInterface::class);
         $resolver->expects($this->once())->method('resolve');
         $resolver->expects($this->once())->method('getManagerSteps')->willReturn([new \stdClass]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected Pierstoval\Bundle\CharacterManagerBundle\Action\StepActionInterface instance, "stdClass" given.');
+
         $stub->configure('', '', CharacterStub::class, $resolver);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Expected Pierstoval\Bundle\CharacterManagerBundle\Action\StepActionInterface instance, "string" given.
-     */
     public function test configure with wrong steps type throws exception()
     {
         $stub = new ConcreteAbstractActionStub();
         $resolver = $this->createMock(StepResolverInterface::class);
         $resolver->expects($this->once())->method('resolve');
         $resolver->expects($this->once())->method('getManagerSteps')->willReturn(['error']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected Pierstoval\Bundle\CharacterManagerBundle\Action\StepActionInterface instance, "string" given.');
+
         $stub->configure('', '', CharacterStub::class, $resolver);
     }
 
@@ -127,20 +126,13 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
 
         $response = $stub1->nextStep();
 
-        static::assertInstanceOf(RedirectResponse::class, $response);
         static::assertEquals(2, $request->getSession()->get('step.test_manager'));
         static::assertTrue($response->isRedirect('/steps/step_2'));
     }
 
     public function test getCurrentCharacter with a correct session value()
     {
-        $stub = new ConcreteAbstractActionStub();
-        $stepStub = StepStub::createStub();
-        $resolver = $this->createMock(StepResolverInterface::class);
-        $resolver->expects($this->once())->method('resolve')->willReturn($stepStub);
-        $resolver->expects($this->once())->method('getManagerSteps')->willReturn([$stepStub]);
-
-        $stub->configure($stepStub->getManagerName(), $stepStub->getName(), CharacterStub::class, $resolver);
+        $stub = $this->getDefaultStub();
 
         // Prepare request & session
         $request = $this->createRequest();
@@ -154,13 +146,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
 
     public function test getCharacterProperty with no key()
     {
-        $stub = new ConcreteAbstractActionStub();
-        $stepStub = StepStub::createStub();
-        $resolver = $this->createMock(StepResolverInterface::class);
-        $resolver->expects($this->once())->method('resolve')->willReturn($stepStub);
-        $resolver->expects($this->once())->method('getManagerSteps')->willReturn([$stepStub]);
-
-        $stub->configure($stepStub->getManagerName(), $stepStub->getName(), CharacterStub::class, $resolver);
+        $stub = $this->getDefaultStub();
 
         // Prepare request & session
         $request = $this->createRequest();
@@ -174,13 +160,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
 
     public function test getCharacterProperty with valid key()
     {
-        $stub = new ConcreteAbstractActionStub();
-        $stepStub = StepStub::createStub();
-        $resolver = $this->createMock(StepResolverInterface::class);
-        $resolver->expects($this->once())->method('resolve')->willReturn($stepStub);
-        $resolver->expects($this->once())->method('getManagerSteps')->willReturn([$stepStub]);
-
-        $stub->configure($stepStub->getManagerName(), $stepStub->getName(), CharacterStub::class, $resolver);
+        $stub = $this->getDefaultStub();
 
         // Prepare request & session
         $request = $this->createRequest();
@@ -194,13 +174,7 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
 
     public function test getCharacterProperty with non existent key()
     {
-        $stub = new ConcreteAbstractActionStub();
-        $stepStub = StepStub::createStub();
-        $resolver = $this->createMock(StepResolverInterface::class);
-        $resolver->expects($this->once())->method('resolve')->willReturn($stepStub);
-        $resolver->expects($this->once())->method('getManagerSteps')->willReturn([$stepStub]);
-
-        $stub->configure($stepStub->getManagerName(), $stepStub->getName(), CharacterStub::class, $resolver);
+        $stub = $this->getDefaultStub();
 
         $stub->setRequest($this->createRequest());
 
@@ -281,25 +255,20 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
 
         $response = $stub->goToStep(3);
 
-        static::assertInstanceOf(RedirectResponse::class, $response);
         static::assertTrue($response->isRedirect('/steps/step_3'));
         static::assertSame(3, $request->getSession()->get('step.test_manager'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot use Pierstoval\Bundle\CharacterManagerBundle\Action\AbstractStepAction::goToStep if no router is injected in AbstractStepAction.
-     */
     public function test goToStep throws exception if no router()
     {
         $stub = new ConcreteAbstractActionStub();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot use Pierstoval\Bundle\CharacterManagerBundle\Action\AbstractStepAction::goToStep if no router is injected in AbstractStepAction.');
+
         $stub->goToStep(1);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid step: 25
-     */
     public function test goToStep throws exception if step does not exist()
     {
         /** @var RouterInterface|MockObject $router */
@@ -307,27 +276,31 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
 
         $stub = new ConcreteAbstractActionStub();
         $stub->setRouter($router);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid step: 25');
+
         $stub->goToStep(25);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Request is not set in step action.
-     */
     public function test flashMessage should throw exception if no request()
     {
         $stub = new ConcreteAbstractActionStub();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Request is not set in step action.');
+
         $stub->flashMessage('message');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The session must be available to manage characters. Did you forget to enable the session in the framework?
-     */
     public function test flashMessage should throw exception if no session()
     {
         $stub = new ConcreteAbstractActionStub();
         $stub->setRequest(new Request());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The session must be available to manage characters. Did you forget to enable the session in the framework?');
+
         $stub->flashMessage('message');
     }
 
@@ -386,34 +359,34 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         static::assertSame(['translated'], $stub->getSession()->getFlashBag()->get('error'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Request is not set in step action.
-     */
     public function test update current step should throw exception if no request()
     {
         $stub = new ConcreteAbstractActionStub();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Request is not set in step action.');
+
         $stub->updateCharacterStep(null);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Request is not set in step action.
-     */
     public function test getCurrentCharacter should throw exception if no request()
     {
         $stub = new ConcreteAbstractActionStub();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Request is not set in step action.');
+
         $stub->getCurrentCharacter();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The session must be available to manage characters. Did you forget to enable the session in the framework?
-     */
     public function test getCurrentCharacter should throw exception if no session()
     {
         $stub = new ConcreteAbstractActionStub();
         $stub->setRequest(new Request());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The session must be available to manage characters. Did you forget to enable the session in the framework?');
+
         $stub->getCurrentCharacter();
     }
 
@@ -426,15 +399,27 @@ class AbstractActionTest extends AbstractGeneratorControllerTest
         $stub->configure('', '', \stdClass::class, $this->createMock(StepResolverInterface::class));
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage The session must be available to manage characters. Did you forget to enable the session in the framework?
-     */
     public function test flash message when session is not available()
     {
         $action = new ConcreteAbstractActionStub();
         $action->setRequest(new Request());
 
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The session must be available to manage characters. Did you forget to enable the session in the framework?');
+
         $action->flashMessage('Whatever, it should throw an exception anyway.');
+    }
+
+    private function getDefaultStub(): ConcreteAbstractActionStub
+    {
+        $stub = new ConcreteAbstractActionStub();
+        $stepStub = StepStub::createStub();
+        $resolver = $this->createMock(StepResolverInterface::class);
+        $resolver->expects($this->once())->method('resolve')->willReturn($stepStub);
+        $resolver->expects($this->once())->method('getManagerSteps')->willReturn([$stepStub]);
+
+        $stub->configure($stepStub->getManagerName(), $stepStub->getName(), CharacterStub::class, $resolver);
+
+        return $stub;
     }
 }

--- a/Tests/Controller/AbstractGeneratorControllerTest.php
+++ b/Tests/Controller/AbstractGeneratorControllerTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -16,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Pierstoval\Bundle\CharacterManagerBundle\Controller\GeneratorController;
 use Pierstoval\Bundle\CharacterManagerBundle\Registry\ActionsRegistryInterface;
 use Pierstoval\Bundle\CharacterManagerBundle\Resolver\StepResolverInterface;
-use \Pierstoval\Bundle\CharacterManagerBundle\Tests\Fixtures\Stubs\Action\ConcreteAbstractActionStub;
+use Pierstoval\Bundle\CharacterManagerBundle\Tests\Fixtures\Stubs\Action\ConcreteAbstractActionStub;
 use Pierstoval\Bundle\CharacterManagerBundle\Tests\Fixtures\Stubs\Entity\CharacterStub;
 use Pierstoval\Bundle\CharacterManagerBundle\Tests\RequestTestTrait;
 use Symfony\Component\Routing\RouterInterface;
@@ -30,9 +32,7 @@ abstract class AbstractGeneratorControllerTest extends TestCase
      * @param MockObject|StepResolverInterface    $resolver
      * @param MockObject|TranslatorInterface      $translator
      * @param MockObject|RouterInterface          $router
-     * @param MockObject|ActionsRegistryInterface $actionsRegistry
-     *
-     * @return GeneratorController
+     * @param ActionsRegistryInterface|MockObject $actionsRegistry
      */
     protected function createController(
         StepResolverInterface $resolver = null,
@@ -65,12 +65,12 @@ abstract class AbstractGeneratorControllerTest extends TestCase
 
         // Will be used to populate missing data
         $baseStep = [
-            'action'         => ConcreteAbstractActionStub::class,
-            'label'          => '',
-            'number'         => 1,
-            'name'           => '01',
-            'manager_name'   => $managerName,
-            'dependencies'   => [],
+            'action' => ConcreteAbstractActionStub::class,
+            'label' => '',
+            'number' => 1,
+            'name' => '01',
+            'manager_name' => $managerName,
+            'dependencies' => [],
             'onchange_clear' => [],
         ];
 

--- a/Tests/Controller/GeneratorController/IndexActionTest.php
+++ b/Tests/Controller/GeneratorController/IndexActionTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -14,12 +16,12 @@ namespace Pierstoval\Bundle\CharacterManagerBundle\Tests\Controller\GeneratorCon
 use Pierstoval\Bundle\CharacterManagerBundle\Resolver\StepResolver;
 use Pierstoval\Bundle\CharacterManagerBundle\Tests\Controller\AbstractGeneratorControllerTest;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
 
 class IndexActionTest extends AbstractGeneratorControllerTest
 {
-    public function test index needs session()
+    public function test index needs session(): void
     {
         $controller = $this->createController();
         $request = new Request();
@@ -30,7 +32,7 @@ class IndexActionTest extends AbstractGeneratorControllerTest
         $controller->indexAction($request);
     }
 
-    public function test index with no configuration returns 404()
+    public function test index with no configuration returns 404(): void
     {
         $stepsResolver = new StepResolver(['manager' => ['steps' => []]]);
 
@@ -43,14 +45,14 @@ class IndexActionTest extends AbstractGeneratorControllerTest
         $controller->indexAction($request);
     }
 
-    public function test index with no step in session redirects to first step()
+    public function test index with no step in session redirects to first step(): void
     {
         $resolver = new StepResolver([
             'manager_one' => $this->createManagerConfiguration('manager_one'),
         ]);
 
         $router = $this->createMock(RouterInterface::class);
-        $router->expects(self::once())
+        $router->expects(static::once())
             ->method('generate')
             ->with('pierstoval_character_generator_step', ['requestStep' => '01'])
             ->willReturn('/generate/01')
@@ -64,14 +66,14 @@ class IndexActionTest extends AbstractGeneratorControllerTest
         static::assertSame('/generate/01', $response->headers->get('Location'));
     }
 
-    public function test index with manager in session redirects to first step with manager name()
+    public function test index with manager in session redirects to first step with manager name(): void
     {
         $resolver = new StepResolver([
             'manager_one' => $this->createManagerConfiguration('manager_one'),
         ]);
 
         $router = $this->createMock(RouterInterface::class);
-        $router->expects(self::once())
+        $router->expects(static::once())
             ->method('generate')
             ->with('pierstoval_character_generator_step', ['requestStep' => '01', 'manager' => 'manager_one'])
             ->willReturn('/generate/manager_one/01')

--- a/Tests/Controller/GeneratorController/IndexActionTest.php
+++ b/Tests/Controller/GeneratorController/IndexActionTest.php
@@ -13,34 +13,32 @@ namespace Pierstoval\Bundle\CharacterManagerBundle\Tests\Controller\GeneratorCon
 
 use Pierstoval\Bundle\CharacterManagerBundle\Resolver\StepResolver;
 use Pierstoval\Bundle\CharacterManagerBundle\Tests\Controller\AbstractGeneratorControllerTest;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class IndexActionTest extends AbstractGeneratorControllerTest
 {
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Session is mandatory when using the character generator.
-     */
     public function test index needs session()
     {
         $controller = $this->createController();
         $request = new Request();
 
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Session is mandatory when using the character generator.');
+
         $controller->indexAction($request);
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @expectedExceptionMessage No step found to start the generator.
-     */
     public function test index with no configuration returns 404()
     {
         $stepsResolver = new StepResolver(['manager' => ['steps' => []]]);
 
         $controller = $this->createController($stepsResolver);
         $request = $this->createRequest();
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('No step found to start the generator.');
 
         $controller->indexAction($request);
     }
@@ -63,7 +61,6 @@ class IndexActionTest extends AbstractGeneratorControllerTest
 
         $response = $controller->indexAction($request);
 
-        static::assertInstanceOf(RedirectResponse::class, $response);
         static::assertSame('/generate/01', $response->headers->get('Location'));
     }
 
@@ -85,8 +82,6 @@ class IndexActionTest extends AbstractGeneratorControllerTest
 
         $response = $controller->indexAction($request, 'manager_one');
 
-        static::assertInstanceOf(RedirectResponse::class, $response);
         static::assertSame('/generate/manager_one/01', $response->headers->get('Location'));
     }
-
 }

--- a/Tests/Controller/GeneratorController/ResetCharacterActionTest.php
+++ b/Tests/Controller/GeneratorController/ResetCharacterActionTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -22,7 +24,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ResetCharacterActionTest extends AbstractGeneratorControllerTest
 {
-    public function test reset needs session()
+    public function test reset needs session(): void
     {
         $controller = $this->createController();
         $request = new Request();
@@ -33,22 +35,22 @@ class ResetCharacterActionTest extends AbstractGeneratorControllerTest
         $controller->resetCharacterAction($request);
     }
 
-    public function test reset session and flash message()
+    public function test reset session and flash message(): void
     {
         $router = $this->createMock(RouterInterface::class);
-        $router->expects(self::once())
+        $router->expects(static::once())
             ->method('generate')
             ->with('pierstoval_character_generator_index')
             ->willReturn('/generate/')
         ;
         $translator = $this->createMock(TranslatorInterface::class);
-        $translator->expects(self::once())
+        $translator->expects(static::once())
             ->method('trans')
             ->with('steps.reset.character', [], 'PierstovalCharacterManager')
             ->willReturn('Translated flash message')
         ;
         $stepResolver = $this->createMock(StepResolverInterface::class);
-        $stepResolver->expects($this->once())
+        $stepResolver->expects(static::once())
             ->method('resolveManagerName')
             ->with(null)
             ->willReturn('manager_test')
@@ -74,16 +76,16 @@ class ResetCharacterActionTest extends AbstractGeneratorControllerTest
         static::assertSame('/generate/', $response->headers->get('location'));
     }
 
-    public function test reset session and flash message without translator()
+    public function test reset session and flash message without translator(): void
     {
         $router = $this->createMock(RouterInterface::class);
-        $router->expects(self::once())
+        $router->expects(static::once())
             ->method('generate')
             ->with('pierstoval_character_generator_index')
             ->willReturn('/generate/')
         ;
         $stepResolver = $this->createMock(StepResolverInterface::class);
-        $stepResolver->expects($this->once())
+        $stepResolver->expects(static::once())
             ->method('resolveManagerName')
             ->with(null)
             ->willReturn('manager_test')

--- a/Tests/Controller/GeneratorController/ResetCharacterActionTest.php
+++ b/Tests/Controller/GeneratorController/ResetCharacterActionTest.php
@@ -22,14 +22,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ResetCharacterActionTest extends AbstractGeneratorControllerTest
 {
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Session is mandatory when using the character generator.
-     */
     public function test reset needs session()
     {
         $controller = $this->createController();
         $request = new Request();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Session is mandatory when using the character generator.');
 
         $controller->resetCharacterAction($request);
     }

--- a/Tests/Controller/GeneratorController/ResetStepActionTest.php
+++ b/Tests/Controller/GeneratorController/ResetStepActionTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -15,13 +17,13 @@ use Pierstoval\Bundle\CharacterManagerBundle\Resolver\StepResolver;
 use Pierstoval\Bundle\CharacterManagerBundle\Tests\Controller\AbstractGeneratorControllerTest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ResetStepActionTest extends AbstractGeneratorControllerTest
 {
-    public function test reset step needs session()
+    public function test reset step needs session(): void
     {
         $controller = $this->createController();
         $request = new Request();
@@ -32,7 +34,7 @@ class ResetStepActionTest extends AbstractGeneratorControllerTest
         $controller->resetStepAction($request, '');
     }
 
-    public function test reset step with non existent name()
+    public function test reset step with non existent name(): void
     {
         $resolver = new StepResolver([
             'manager_one' => $this->createManagerConfiguration('manager_one'),
@@ -46,12 +48,12 @@ class ResetStepActionTest extends AbstractGeneratorControllerTest
         $controller->resetStepAction($this->createRequest(), 'non_existent_step');
     }
 
-    public function test reset step removes onchange clear steps()
+    public function test reset step removes onchange clear steps(): void
     {
         $resolver = new StepResolver([
             'manager_one' => $this->createManagerConfiguration('manager_one', [
                 '01' => [
-                    'name'           => '01',
+                    'name' => '01',
                     'onchange_clear' => ['03'],
                 ],
                 '02' => [
@@ -63,13 +65,13 @@ class ResetStepActionTest extends AbstractGeneratorControllerTest
             ]),
         ]);
         $router = $this->createMock(RouterInterface::class);
-        $router->expects(self::once())
+        $router->expects(static::once())
             ->method('generate')
             ->with('pierstoval_character_generator_step', ['requestStep' => '01'])
             ->willReturn('/generate/01')
         ;
         $translator = $this->createMock(TranslatorInterface::class);
-        $translator->expects(self::once())
+        $translator->expects(static::once())
             ->method('trans')
             ->with('steps.reset.step', [], 'PierstovalCharacterManager')
             ->willReturn('Translated flash message')
@@ -90,12 +92,12 @@ class ResetStepActionTest extends AbstractGeneratorControllerTest
 
         static::assertTrue($response->isRedirect('/generate/01'));
         static::assertSame([
-            '02' => 'Should be kept'
+            '02' => 'Should be kept',
         ], $session->get('character.manager_one'));
         static::assertSame(['Translated flash message'], $session->getFlashBag()->get('success'));
     }
 
-    public function test reset step with multiple managers correctly redirects()
+    public function test reset step with multiple managers correctly redirects(): void
     {
         $resolver = new StepResolver([
             'manager_one' => $this->createManagerConfiguration('manager_one', [
@@ -110,7 +112,7 @@ class ResetStepActionTest extends AbstractGeneratorControllerTest
             ]),
         ]);
         $router = $this->createMock(RouterInterface::class);
-        $router->expects(self::once())
+        $router->expects(static::once())
             ->method('generate')
             ->with('pierstoval_character_generator_step', ['requestStep' => '01', 'manager' => 'manager_two'])
             ->willReturn('/generate/manager_two/01')

--- a/Tests/Controller/GeneratorController/StepActionTest.php
+++ b/Tests/Controller/GeneratorController/StepActionTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -13,19 +15,19 @@ namespace Pierstoval\Bundle\CharacterManagerBundle\Tests\Controller\GeneratorCon
 
 use Pierstoval\Bundle\CharacterManagerBundle\Registry\ActionsRegistry;
 use Pierstoval\Bundle\CharacterManagerBundle\Resolver\StepResolver;
-use \Pierstoval\Bundle\CharacterManagerBundle\Tests\Fixtures\Stubs\Action\ConcreteAbstractActionStub;
 use Pierstoval\Bundle\CharacterManagerBundle\Tests\Controller\AbstractGeneratorControllerTest;
+use Pierstoval\Bundle\CharacterManagerBundle\Tests\Fixtures\Stubs\Action\ConcreteAbstractActionStub;
 use Pierstoval\Bundle\CharacterManagerBundle\Tests\Fixtures\Stubs\Entity\CharacterStub;
 use Pierstoval\Bundle\CharacterManagerBundle\Tests\Fixtures\Stubs\Model\StepStub;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class StepActionTest extends AbstractGeneratorControllerTest
 {
-    public function test step action needs session()
+    public function test step action needs session(): void
     {
         $controller = $this->createController();
         $request = new Request();
@@ -36,7 +38,7 @@ class StepActionTest extends AbstractGeneratorControllerTest
         $controller->stepAction($request, '');
     }
 
-    public function test step action with non existent name()
+    public function test step action with non existent name(): void
     {
         $resolver = new StepResolver([
             'manager_one' => $this->createManagerConfiguration('manager_one'),
@@ -50,7 +52,7 @@ class StepActionTest extends AbstractGeneratorControllerTest
         $controller->stepAction($this->createRequest(), 'non_existent_step');
     }
 
-    public function test step action should execute action class()
+    public function test step action should execute action class(): void
     {
         $resolver = new StepResolver([
             'test_manager' => $this->createManagerConfiguration('test_manager', [
@@ -73,13 +75,13 @@ class StepActionTest extends AbstractGeneratorControllerTest
         static::assertSame('Stub response based on abstract class', $response->getContent());
     }
 
-    public function test step action should check for dependencies()
+    public function test step action should check for dependencies(): void
     {
         $resolver = new StepResolver([
             'test_manager' => $this->createManagerConfiguration('test_manager', [
                 'test_step' => [
                     'name' => 'test_step',
-                    'label' => 'Test step one'
+                    'label' => 'Test step one',
                 ],
                 'second_step' => [
                     'name' => 'second_step',
@@ -90,13 +92,13 @@ class StepActionTest extends AbstractGeneratorControllerTest
             ]),
         ]);
         $router = $this->createMock(RouterInterface::class);
-        $router->expects(self::once())
+        $router->expects(static::once())
             ->method('generate')
             ->with('pierstoval_character_generator_index')
             ->willReturn('/generate/manager_one/test_step')
         ;
         $translator = $this->createMock(TranslatorInterface::class);
-        $translator->expects(self::once())
+        $translator->expects(static::once())
             ->method('trans')
             ->with('steps.dependency_not_set', [
                 '%current_step%' => 'Test step two',

--- a/Tests/Controller/GeneratorControllerFunctionalTest.php
+++ b/Tests/Controller/GeneratorControllerFunctionalTest.php
@@ -12,7 +12,7 @@
 namespace Pierstoval\Bundle\CharacterManagerBundle\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Tests\WebTestCase as PiersTestCase;
+use Pierstoval\Tests\WebTestCase as PiersTestCase;
 
 class GeneratorControllerFunctionalTest extends WebTestCase
 {
@@ -20,7 +20,7 @@ class GeneratorControllerFunctionalTest extends WebTestCase
 
     public function test generate redirects to first step()
     {
-        $client = $this->getClient();
+        $client = $this->getHttpClient();
 
         $client->getKernel()->boot();
 
@@ -32,7 +32,7 @@ class GeneratorControllerFunctionalTest extends WebTestCase
 
     public function test base step route renders correctly()
     {
-        $client = $this->getClient();
+        $client = $this->getHttpClient();
 
         $client->getKernel()->boot();
 
@@ -44,7 +44,7 @@ class GeneratorControllerFunctionalTest extends WebTestCase
 
     public function test non existent step route throws 404()
     {
-        $client = $this->getClient();
+        $client = $this->getHttpClient();
 
         $client->getKernel()->boot();
 

--- a/Tests/Controller/GeneratorControllerFunctionalTest.php
+++ b/Tests/Controller/GeneratorControllerFunctionalTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -11,14 +13,14 @@
 
 namespace Pierstoval\Bundle\CharacterManagerBundle\Tests\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Pierstoval\Tests\WebTestCase as PiersTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class GeneratorControllerFunctionalTest extends WebTestCase
 {
     use PiersTestCase;
 
-    public function test generate redirects to first step()
+    public function test generate redirects to first step(): void
     {
         $client = $this->getHttpClient();
 
@@ -30,7 +32,7 @@ class GeneratorControllerFunctionalTest extends WebTestCase
         static::assertSame('/generate/step_01', $client->getResponse()->headers->get('Location'));
     }
 
-    public function test base step route renders correctly()
+    public function test base step route renders correctly(): void
     {
         $client = $this->getHttpClient();
 
@@ -42,7 +44,7 @@ class GeneratorControllerFunctionalTest extends WebTestCase
         static::assertSame('Stub response based on abstract class', $client->getResponse()->getContent());
     }
 
-    public function test non existent step route throws 404()
+    public function test non existent step route throws 404(): void
     {
         $client = $this->getHttpClient();
 

--- a/Tests/Controller/MultipleManagersGeneratorControllerFunctionalTest.php
+++ b/Tests/Controller/MultipleManagersGeneratorControllerFunctionalTest.php
@@ -12,7 +12,7 @@
 namespace Pierstoval\Bundle\CharacterManagerBundle\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Tests\WebTestCase as PiersTestCase;
+use Pierstoval\Tests\WebTestCase as PiersTestCase;
 
 class MultipleManagersGeneratorControllerFunctionalTest extends WebTestCase
 {
@@ -26,7 +26,7 @@ class MultipleManagersGeneratorControllerFunctionalTest extends WebTestCase
 
     public function test main generate redirects to first step()
     {
-        $client = $this->getClient();
+        $client = $this->getHttpClient();
 
         $client->getKernel()->boot();
 
@@ -38,7 +38,7 @@ class MultipleManagersGeneratorControllerFunctionalTest extends WebTestCase
 
     public function test other generate redirects to first step()
     {
-        $client = $this->getClient();
+        $client = $this->getHttpClient();
 
         $client->getKernel()->boot();
 

--- a/Tests/Controller/MultipleManagersGeneratorControllerFunctionalTest.php
+++ b/Tests/Controller/MultipleManagersGeneratorControllerFunctionalTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -11,20 +13,14 @@
 
 namespace Pierstoval\Bundle\CharacterManagerBundle\Tests\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Pierstoval\Tests\WebTestCase as PiersTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class MultipleManagersGeneratorControllerFunctionalTest extends WebTestCase
 {
     use PiersTestCase;
 
-    protected static function createKernel(array $options = [])
-    {
-        $options['environment'] = 'test_more_managers';
-        return parent::createKernel($options);
-    }
-
-    public function test main generate redirects to first step()
+    public function test main generate redirects to first step(): void
     {
         $client = $this->getHttpClient();
 
@@ -36,7 +32,7 @@ class MultipleManagersGeneratorControllerFunctionalTest extends WebTestCase
         static::assertSame('/main/generate/step_01', $client->getResponse()->headers->get('Location'));
     }
 
-    public function test other generate redirects to first step()
+    public function test other generate redirects to first step(): void
     {
         $client = $this->getHttpClient();
 
@@ -46,5 +42,12 @@ class MultipleManagersGeneratorControllerFunctionalTest extends WebTestCase
 
         static::assertSame(302, $client->getResponse()->getStatusCode());
         static::assertSame('/other/generate/step_01', $client->getResponse()->headers->get('Location'));
+    }
+
+    protected static function createKernel(array $options = [])
+    {
+        $options['environment'] = 'test_more_managers';
+
+        return parent::createKernel($options);
     }
 }

--- a/Tests/DependencyInjection/ExtensionTest.php
+++ b/Tests/DependencyInjection/ExtensionTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -27,10 +29,10 @@ class ExtensionTest extends TestCase
      * @param $config
      * @param $expected
      */
-    public function test yaml configurations($config, $expected)
+    public function test yaml configurations($config, $expected): void
     {
         $container = new ContainerBuilder();
-        $ext       = new PierstovalCharacterManagerExtension();
+        $ext = new PierstovalCharacterManagerExtension();
         $stepsPass = new StepsPass();
 
         // Add the default step service
@@ -45,37 +47,37 @@ class ExtensionTest extends TestCase
         // Sorting the arrays by key name avoid issues with PHP7 and Yaml parsing that sometimes store the keys in the wrong order
 
         foreach ($expected['pierstoval_character_manager'] as $key => $expectedValue) {
-            if (is_array($expectedValue)) {
-                ksort($expectedValue);
-                if (is_array(current($expectedValue))) {
-                    $expectedValue = array_map('ksort', $expectedValue);
+            if (\is_array($expectedValue)) {
+                \ksort($expectedValue);
+                if (\is_array(\current($expectedValue))) {
+                    $expectedValue = \array_map('ksort', $expectedValue);
                 }
             }
-            $parameterValue = $container->getParameter($parameter = "pierstoval_character_manager.$key");
-            if (is_array($parameterValue)) {
-                ksort($parameterValue);
-                if (is_array(current($parameterValue))) {
-                    $parameterValue = array_map('ksort', $parameterValue);
+            $parameterValue = $container->getParameter($parameter = "pierstoval_character_manager.{$key}");
+            if (\is_array($parameterValue)) {
+                \ksort($parameterValue);
+                if (\is_array(\current($parameterValue))) {
+                    $parameterValue = \array_map('ksort', $parameterValue);
                 }
             }
-            static::assertSame($expectedValue, $parameterValue, "$parameter is not the same as expected");
+            static::assertSame($expectedValue, $parameterValue, "{$parameter} is not the same as expected");
         }
     }
 
     /**
      * Provide all "extension_test" directory configs and test them through the extension.
      */
-    public function provideYamlConfiguration(): \Generator
+    public function provideYamlConfiguration(): Generator
     {
         $dir = __DIR__.'/../Fixtures/App/extension_test/';
 
-        $configFiles = glob($dir.'config_*.yaml');
+        $configFiles = \glob($dir.'config_*.yaml');
 
-        sort($configFiles);
+        \sort($configFiles);
 
         foreach ($configFiles as $file) {
-            $content = Yaml::parse(file_get_contents($file));
-            yield basename($file) => [
+            $content = Yaml::parse(\file_get_contents($file));
+            yield \basename($file) => [
                 $content['input'],
                 $content['output'],
             ];

--- a/Tests/DependencyInjection/StepsPassTest.php
+++ b/Tests/DependencyInjection/StepsPassTest.php
@@ -30,12 +30,12 @@ class StepsPassTest extends TestCase
      */
     public function test compiler pass should not work if extension not processed(
         array $config,
-        string $expectedException,
-        string $expectedExceptionMessage,
+        string $expectException,
+        string $expectExceptionMessage,
         string $stepClass
     ) {
-        $this->expectException($expectedException);
-        $this->expectExceptionMessage($expectedExceptionMessage);
+        $this->expectException($expectException);
+        $this->expectExceptionMessage($expectExceptionMessage);
 
         $stepsPass = new StepsPass();
 
@@ -164,12 +164,8 @@ class StepsPassTest extends TestCase
 
         $container->register(ActionsRegistry::class);
 
-        $inlineStub1 = new class extends ConcreteAbstractActionStub
-        {
-        };
-        $inlineStub2 = new class extends ConcreteAbstractActionStub
-        {
-        };
+        $inlineStub1 = new TestStub();
+        $inlineStub2 = new TestStub();
 
         $container->setParameter('pierstoval_character_manager.managers', [
             'main' => [
@@ -217,4 +213,8 @@ class StepsPassTest extends TestCase
         static::assertSame(1, $managersConfiguration['another_manager']['steps']['01']['number']);
         static::assertSame(2, $managersConfiguration['another_manager']['steps']['02']['number']);
     }
+}
+
+class TestStub extends ConcreteAbstractActionStub
+{
 }

--- a/Tests/Entity/AbstractCharacterTest.php
+++ b/Tests/Entity/AbstractCharacterTest.php
@@ -20,7 +20,7 @@ class AbstractCharacterTest extends TestCase
     {
         $character = new CharacterStub();
 
-        static::assertInternalType('string', $character->getName());
-        static::assertInternalType('string', $character->getNameSlug());
+        static::assertIsString($character->getName());
+        static::assertIsString($character->getNameSlug());
     }
 }

--- a/Tests/Entity/AbstractCharacterTest.php
+++ b/Tests/Entity/AbstractCharacterTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -16,7 +18,7 @@ use Pierstoval\Bundle\CharacterManagerBundle\Tests\Fixtures\Stubs\Entity\Charact
 
 class AbstractCharacterTest extends TestCase
 {
-    public function test public getters return types()
+    public function test public getters return types(): void
     {
         $character = new CharacterStub();
 

--- a/Tests/Fixtures/App/TestKernel.php
+++ b/Tests/Fixtures/App/TestKernel.php
@@ -40,6 +40,21 @@ class TestKernel extends Kernel
 
     public function getRootDir()
     {
-        return $this->getProjectDir().'/build';
+        return \dirname(__DIR__, 3);
+    }
+
+    public function getProjectDir()
+    {
+        return $this->getRootDir();
+    }
+
+    public function getLogDir()
+    {
+        return $this->getProjectDir().'/build/log/'.$this->environment;
+    }
+
+    public function getCacheDir()
+    {
+        return $this->getProjectDir().'/build/cache/'.$this->environment;
     }
 }

--- a/Tests/Fixtures/App/TestKernel.php
+++ b/Tests/Fixtures/App/TestKernel.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -33,7 +35,7 @@ class TestKernel extends Kernel
     /**
      * Loads the container configuration.
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/config/config_'.$this->environment.'.yaml');
     }

--- a/Tests/Fixtures/Stubs/Action/ConcreteAbstractActionStub.php
+++ b/Tests/Fixtures/Stubs/Action/ConcreteAbstractActionStub.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>

--- a/Tests/Fixtures/Stubs/Action/StepActionStub.php
+++ b/Tests/Fixtures/Stubs/Action/StepActionStub.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>

--- a/Tests/Fixtures/Stubs/Action/StepActionStub.php
+++ b/Tests/Fixtures/Stubs/Action/StepActionStub.php
@@ -39,4 +39,9 @@ class StepActionStub implements StepActionInterface
     public function configure(string $managerName, string $stepName, string $characterClassName, StepResolverInterface $resolver): void
     {
     }
+
+    public function stepName(): string
+    {
+        return $this->getStep()->getName();
+    }
 }

--- a/Tests/Fixtures/Stubs/Entity/CharacterStub.php
+++ b/Tests/Fixtures/Stubs/Entity/CharacterStub.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -15,7 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Pierstoval\Bundle\CharacterManagerBundle\Entity\Character as BaseCharacter;
 
 /**
- * @ORM\Entity()
+ * @ORM\Entity
  * @ORM\Table(name="character_stubs")
  */
 class CharacterStub extends BaseCharacter
@@ -33,9 +35,6 @@ class CharacterStub extends BaseCharacter
         parent::__construct('Stub characte', 'stub-character');
     }
 
-    /**
-     * @return int
-     */
     public function getId(): int
     {
         return $this->id;

--- a/Tests/Fixtures/Stubs/Model/StepStub.php
+++ b/Tests/Fixtures/Stubs/Model/StepStub.php
@@ -1,7 +1,9 @@
 <?php
 
-/**
- * This file is part of the CharacterManagerBundle package.
+declare(strict_types=1);
+
+/*
+ * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
  *
@@ -18,14 +20,14 @@ class StepStub extends Step
 {
     public static function createStub(array $data = [])
     {
-        $data = array_merge([
+        $data = \array_merge([
             'number' => 0,
             'name' => 'test_step',
             'label' => 'Test step',
             'action' => ConcreteAbstractActionStub::class,
             'manager_name' => 'test_manager',
             'onchange_clear' => [], // On cache clear
-            'dependencies' => [] // Dependencies
+            'dependencies' => [], // Dependencies
         ], $data);
 
         return static::createFromData($data);

--- a/Tests/Registry/ActionsRegistryTest.php
+++ b/Tests/Registry/ActionsRegistryTest.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the PierstovalCharacterManagerBundle package.
+ *
+ * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Pierstoval\Bundle\CharacterManagerBundle\Tests\Registry;
 
 use PHPUnit\Framework\TestCase;
@@ -9,7 +20,7 @@ use Pierstoval\Bundle\CharacterManagerBundle\Registry\ActionsRegistry;
 
 class ActionsRegistryTest extends TestCase
 {
-    public function test getAction with no actions throws exception()
+    public function test getAction with no actions throws exception(): void
     {
         $registry = new ActionsRegistry();
 
@@ -19,17 +30,19 @@ class ActionsRegistryTest extends TestCase
         $registry->getAction('whatever');
     }
 
-    public function test getAction with no matching manager throws exception()
+    public function test getAction with no matching manager throws exception(): void
     {
         $step = $this->createMock(StepInterface::class);
-        $step->expects($this->once())
+        $step->expects(static::once())
             ->method('getName')
-            ->willReturn('default_step_name');
+            ->willReturn('default_step_name')
+        ;
 
         $action = $this->createMock(StepActionInterface::class);
-        $action->expects($this->once())
+        $action->expects(static::once())
             ->method('stepName')
-            ->willReturn($step->getName());
+            ->willReturn($step->getName())
+        ;
 
         $registry = new ActionsRegistry();
         $registry->addStepAction('default', $action->stepName(), $action);
@@ -40,17 +53,19 @@ class ActionsRegistryTest extends TestCase
         $registry->getAction('whatever_step', 'inexistent_manager');
     }
 
-    public function test injecting closure action loads it lazily()
+    public function test injecting closure action loads it lazily(): void
     {
         $step = $this->createMock(StepInterface::class);
-        $step->expects($this->once())
+        $step->expects(static::once())
             ->method('getName')
-            ->willReturn('default_step');
+            ->willReturn('default_step')
+        ;
 
         $action = $this->createMock(StepActionInterface::class);
-        $action->expects($this->once())
+        $action->expects(static::once())
             ->method('stepName')
-            ->willReturn($step->getName());
+            ->willReturn($step->getName())
+        ;
 
         $closure = static function () use ($action) {
             return $action;
@@ -62,17 +77,19 @@ class ActionsRegistryTest extends TestCase
         static::assertSame($action, $registry->getAction('default_step'));
     }
 
-    public function test injecting closure that returns a wrong object throws exception()
+    public function test injecting closure that returns a wrong object throws exception(): void
     {
         $step = $this->createMock(StepInterface::class);
-        $step->expects($this->once())
+        $step->expects(static::once())
             ->method('getName')
-            ->willReturn('default_step');
+            ->willReturn('default_step')
+        ;
 
         $action = $this->createMock(StepActionInterface::class);
-        $action->expects($this->once())
+        $action->expects(static::once())
             ->method('stepName')
-            ->willReturn($step->getName());
+            ->willReturn($step->getName())
+        ;
 
         $closure = static function () use ($action) {
             return 'wrong';
@@ -84,7 +101,10 @@ class ActionsRegistryTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(\sprintf(
             "Lazy-loaded action \"%s\" for character manager \"%s\" must be resolved to an instance of \"%s\".\n\"%s\" given.",
-            'default_step', 'default', StepActionInterface::class, 'string'
+            'default_step',
+            'default',
+            StepActionInterface::class,
+            'string'
         ));
 
         static::assertSame($action, $registry->getAction('default_step'));
@@ -93,17 +113,19 @@ class ActionsRegistryTest extends TestCase
     /**
      * @dataProvider provide manager names
      */
-    public function test getAction with no matching step throws exception(?string $managerName)
+    public function test getAction with no matching step throws exception(?string $managerName): void
     {
         $step = $this->createMock(StepInterface::class);
-        $step->expects($this->once())
+        $step->expects(static::once())
             ->method('getName')
-            ->willReturn('default_step');
+            ->willReturn('default_step')
+        ;
 
         $action = $this->createMock(StepActionInterface::class);
-        $action->expects($this->once())
+        $action->expects(static::once())
             ->method('stepName')
-            ->willReturn($step->getName());
+            ->willReturn($step->getName())
+        ;
 
         $registry = new ActionsRegistry();
         $registry->addStepAction('default', $action->stepName(), $action);

--- a/Tests/RequestTestTrait.php
+++ b/Tests/RequestTestTrait.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>

--- a/Tests/Resolver/StepResolverTest.php
+++ b/Tests/Resolver/StepResolverTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -12,15 +14,15 @@
 namespace Pierstoval\Bundle\CharacterManagerBundle\Tests\Resolver;
 
 use PHPUnit\Framework\TestCase;
+use Pierstoval\Bundle\CharacterManagerBundle\Exception\StepNotFoundException;
 use Pierstoval\Bundle\CharacterManagerBundle\Model\Step;
 use Pierstoval\Bundle\CharacterManagerBundle\Model\StepInterface;
 use Pierstoval\Bundle\CharacterManagerBundle\Resolver\StepResolver;
 use Pierstoval\Bundle\CharacterManagerBundle\Tests\Fixtures\Stubs\Action\ConcreteAbstractActionStub;
-use Pierstoval\Bundle\CharacterManagerBundle\Exception\StepNotFoundException;
 
 class StepResolverTest extends TestCase
 {
-    public function test steps resolver with empty config throws exception()
+    public function test steps resolver with empty config throws exception(): void
     {
         $resolver = new StepResolver();
 
@@ -30,18 +32,18 @@ class StepResolverTest extends TestCase
         $resolver->getManagerSteps();
     }
 
-    public function test steps resolver with single config option()
+    public function test steps resolver with single config option(): void
     {
         $stepsArray = [
             'one' => [
-                'number'         => 1,
-                'name'           => '01',
-                'action'         => ConcreteAbstractActionStub::class,
-                'label'          => '',
+                'number' => 1,
+                'name' => '01',
+                'action' => ConcreteAbstractActionStub::class,
+                'label' => '',
                 'onchange_clear' => [],
-                'dependencies'   => [],
-                'manager_name'   => 'main_manager',
-            ]
+                'dependencies' => [],
+                'manager_name' => 'main_manager',
+            ],
         ];
         $resolver = new StepResolver(['main_manager' => ['steps' => $stepsArray]]);
 
@@ -54,19 +56,19 @@ class StepResolverTest extends TestCase
         static::assertEquals($stepsObjects, $resolver->getManagerSteps('main_manager'));
     }
 
-    public function test resolve non existent step name should throw exception()
+    public function test resolve non existent step name should throw exception(): void
     {
         $resolver = new StepResolver([
             'main_manager' => [
                 'steps' => [
                     'step_1' => [
                         'action' => ConcreteAbstractActionStub::class,
-                        'name' =>  'step_1',
-                        'label' =>  'Step 1',
-                        'dependencies' =>  [],
+                        'name' => 'step_1',
+                        'label' => 'Step 1',
+                        'dependencies' => [],
                         'manager_name' => 'main_manager',
-                        'onchange_clear' =>  [],
-                        'number' =>  1,
+                        'onchange_clear' => [],
+                        'number' => 1,
                     ],
                 ],
             ],
@@ -78,19 +80,19 @@ class StepResolverTest extends TestCase
         $resolver->resolve('non_existent_step');
     }
 
-    public function test resolve non existent step number should throw an exception()
+    public function test resolve non existent step number should throw an exception(): void
     {
         $resolver = new StepResolver([
             'main_manager' => [
                 'steps' => [
                     'step_1' => [
                         'action' => ConcreteAbstractActionStub::class,
-                        'name' =>  'step_1',
-                        'label' =>  'Step 1',
-                        'dependencies' =>  [],
+                        'name' => 'step_1',
+                        'label' => 'Step 1',
+                        'dependencies' => [],
                         'manager_name' => 'main_manager',
-                        'onchange_clear' =>  [],
-                        'number' =>  1,
+                        'onchange_clear' => [],
+                        'number' => 1,
                     ],
                 ],
             ],
@@ -102,16 +104,16 @@ class StepResolverTest extends TestCase
         $resolver->resolveNumber(5);
     }
 
-    public function test resolve step name should return correct step values()
+    public function test resolve step name should return correct step values(): void
     {
         $step1 = [
             'number' => 0,
-            'name' =>  'step_1',
+            'name' => 'step_1',
             'action' => ConcreteAbstractActionStub::class,
-            'label' =>  'Step 1',
+            'label' => 'Step 1',
             'manager_name' => 'main_manager',
-            'onchange_clear' =>  [],
-            'dependencies' =>  [],
+            'onchange_clear' => [],
+            'dependencies' => [],
         ];
 
         $resolver = new StepResolver([
@@ -127,16 +129,16 @@ class StepResolverTest extends TestCase
         $this->makeDefaultStepAssertions($resolvedStep, $step1);
     }
 
-    public function test resolve step number should return correct step()
+    public function test resolve step number should return correct step(): void
     {
         $step1 = [
             'number' => 0,
-            'name' =>  'step_1',
+            'name' => 'step_1',
             'action' => ConcreteAbstractActionStub::class,
-            'label' =>  'Step 1',
+            'label' => 'Step 1',
             'manager_name' => 'main_manager',
-            'onchange_clear' =>  [],
-            'dependencies' =>  [],
+            'onchange_clear' => [],
+            'dependencies' => [],
         ];
 
         $resolver = new StepResolver([
@@ -152,7 +154,7 @@ class StepResolverTest extends TestCase
         $this->makeDefaultStepAssertions($resolvedStep, $step1);
     }
 
-    public function test resolve with no steps should throw exception()
+    public function test resolve with no steps should throw exception(): void
     {
         $resolver = new StepResolver(['test' => ['steps' => []]]);
 
@@ -162,7 +164,7 @@ class StepResolverTest extends TestCase
         $resolver->resolve('non_existent_step');
     }
 
-    public function test resolve number with no steps should throw exception()
+    public function test resolve number with no steps should throw exception(): void
     {
         $resolver = new StepResolver(['test' => ['steps' => []]]);
 
@@ -172,18 +174,18 @@ class StepResolverTest extends TestCase
         $resolver->resolveNumber(0);
     }
 
-    public function test resolve invalid manager should throw exception()
+    public function test resolve invalid manager should throw exception(): void
     {
         $resolver = new StepResolver([
             'main_manager' => [
                 'steps' => [
                     'step_1' => [
-                        'action'         => '',
-                        'label'          => '',
-                        'number'         => 1,
-                        'name'           => '',
-                        'manager_name'   => '',
-                        'dependencies'   => [],
+                        'action' => '',
+                        'label' => '',
+                        'number' => 1,
+                        'name' => '',
+                        'manager_name' => '',
+                        'dependencies' => [],
                         'onchange_clear' => [],
                     ],
                 ],
@@ -196,33 +198,33 @@ class StepResolverTest extends TestCase
         $resolver->resolve('', 'invalid_manager');
     }
 
-    public function test resolve multiple manager names with same steps names()
+    public function test resolve multiple manager names with same steps names(): void
     {
         $resolver = new StepResolver([
             'manager_one' => [
                 'character_class' => '',
-                'steps'           => [
+                'steps' => [
                     '01' => [
-                        'action'         => '',
-                        'label'          => '',
-                        'number'         => 1,
-                        'name'           => '',
-                        'manager_name'   => 'manager_one',
-                        'dependencies'   => [],
+                        'action' => '',
+                        'label' => '',
+                        'number' => 1,
+                        'name' => '',
+                        'manager_name' => 'manager_one',
+                        'dependencies' => [],
                         'onchange_clear' => [],
                     ],
                 ],
             ],
             'manager_two' => [
                 'character_class' => '',
-                'steps'           => [
+                'steps' => [
                     '01' => [
-                        'action'         => '',
-                        'label'          => '',
-                        'number'         => 1,
-                        'name'           => '',
-                        'manager_name'   => 'manager_two',
-                        'dependencies'   => [],
+                        'action' => '',
+                        'label' => '',
+                        'number' => 1,
+                        'name' => '',
+                        'manager_name' => 'manager_two',
+                        'dependencies' => [],
                         'onchange_clear' => [],
                     ],
                 ],
@@ -238,33 +240,33 @@ class StepResolverTest extends TestCase
         static::assertSame('manager_two', $stepFromManagerTwo->getManagerName());
     }
 
-    public function test resolve with no manager name when multiple managers configured should throw exception()
+    public function test resolve with no manager name when multiple managers configured should throw exception(): void
     {
         $resolver = new StepResolver([
             'manager_one' => [
                 'character_class' => '',
-                'steps'           => [
+                'steps' => [
                     '01' => [
-                        'action'         => '',
-                        'label'          => '',
-                        'number'         => 1,
-                        'name'           => '',
-                        'manager_name'   => '',
-                        'dependencies'   => [],
+                        'action' => '',
+                        'label' => '',
+                        'number' => 1,
+                        'name' => '',
+                        'manager_name' => '',
+                        'dependencies' => [],
                         'onchange_clear' => [],
                     ],
                 ],
             ],
             'manager_two' => [
                 'character_class' => '',
-                'steps'           => [
+                'steps' => [
                     '01' => [
-                        'action'         => '',
-                        'label'          => '',
-                        'number'         => 1,
-                        'name'           => '',
-                        'manager_name'   => '',
-                        'dependencies'   => [],
+                        'action' => '',
+                        'label' => '',
+                        'number' => 1,
+                        'name' => '',
+                        'manager_name' => '',
+                        'dependencies' => [],
                         'onchange_clear' => [],
                     ],
                 ],

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -37,7 +37,7 @@ if (!file_exists($file)) {
 }
 $autoload = require $file;
 
-(function(){
+(static function(){
     if (\file_exists($dbFile = __DIR__.'/build/database_test.db')) {
         unlink($dbFile);
     }

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of the PierstovalCharacterManagerBundle package.
  *
  * (c) Alexandre Rock Ancelet <pierstoval@gmail.com>
@@ -32,14 +34,14 @@ if (\function_exists('xdebug_set_filter')) {
 }
 
 $file = __DIR__.'/../vendor/autoload.php';
-if (!file_exists($file)) {
+if (!\file_exists($file)) {
     throw new RuntimeException('Install dependencies to run test suite.');
 }
 $autoload = require $file;
 
-(static function(){
+(static function (): void {
     if (\file_exists($dbFile = __DIR__.'/build/database_test.db')) {
-        unlink($dbFile);
+        \unlink($dbFile);
     }
 
     $kernel = new TestKernel('test', true);

--- a/composer.json
+++ b/composer.json
@@ -13,20 +13,24 @@
     "require": {
         "php": ">=7.2",
         "doctrine/inflector": "^1.1",
-        "symfony/expression-language": "^4.2",
-        "symfony/framework-bundle": "^4.2"
+        "symfony/config": "^4.3|^5.0",
+        "symfony/dependency-injection": "^4.3|^5.0",
+        "symfony/framework-bundle": "^4.3|^5.0",
+        "symfony/http-kernel": "^4.3|^5.0",
+        "symfony/http-foundation": "^4.3|^5.0",
+        "symfony/routing": "^4.3|^5.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.6.8",
         "doctrine/orm": "^2.5",
-        "phpunit/phpunit": "^7.5",
-        "pierstoval/web-test-case": "^0.2.0",
-        "symfony/css-selector": "^4.2",
-        "symfony/console": "^4.2",
-        "symfony/dom-crawler": "^4.2",
-        "symfony/translation": "^4.2",
-        "symfony/twig-bundle": "^4.2",
-        "symfony/yaml": "^4.2"
+        "phpunit/phpunit": "^8.2",
+        "pierstoval/web-test-case": "^0.3",
+        "symfony/css-selector": "^4.3|^5.0",
+        "symfony/console": "^4.3|^5.0",
+        "symfony/dom-crawler": "^4.3|^5.0",
+        "symfony/translation": "^4.3|^5.0",
+        "symfony/twig-bundle": "^4.3|^5.0",
+        "symfony/yaml": "^4.3|^5.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "To inject the object manager in steps and map your Character entities with the ORM",


### PR DESCRIPTION
* Add StepActionInterface::stepName() to simplify step name registration
* Allow Step actions to be lazy services registered as closure
* Removed all PHPUnit deprecations
* Removed Symfony 4.3 deprecations (4.4 may be coming soon)
* Allow Symfony 5.0 in deps
* Require transient dependencies
* Simplify services injection when registering actions in StepsPass
* Use latest version of my WebTestCase to remove Symfony 4.3 BC breaks